### PR TITLE
Fix to allow environment based RABBITMQ_DEFAULT_USER/RABBITMQ_DEFAULT_PASS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Luis Fernando Gomes <your@luiscoms.com.br>
 
 ENV ERLANG_SOLUTIONS_VERSION 1.0-1
 RUN yum update -y && yum clean all
-RUN yum install -y wget && yum clean all
+RUN yum install -y wget epel-release && yum clean all
 RUN yum install -y http://packages.erlang-solutions.com/erlang-solutions-${ERLANG_SOLUTIONS_VERSION}.noarch.rpm && yum clean all
 RUN yum install -y erlang && yum clean all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV HOME /var/lib/rabbitmq
 
 RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq \
 	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq \
-	&& chmod 777 /var/lib/rabbitmq /etc/rabbitmq
+	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq
 
 RUN chown -R rabbitmq:rabbitmq /opt/app-root
 # && \


### PR DESCRIPTION
when I run
```shell
oc new-app --env-file rabbitmq.env luiscoms/openshift-rabbitmq:management
```
with rabbitmq.env
```
RABBITMQ_DEFAULT_USER=development
RABBITMQ_DEFAULT_PASS=abc123
```
Openshift cannot run the pod
```
/usr/local/bin/docker-entrypoint.sh: line 263: /etc/rabbitmq/rabbitmq.config: Permission denied
```

This PR changes the permissions on /etc/rabbitmq/rabbitmq.config in the Dockerfile to allow this to work (I tested this by deploying my fork git repo and it works)
